### PR TITLE
Image carousel and option selection accessibility improvements

### DIFF
--- a/Products/Product View/ProductViewHeader.m
+++ b/Products/Product View/ProductViewHeader.m
@@ -131,7 +131,7 @@
 		_pageControl = [[UIPageControl alloc] init];
 		_pageControl.hidesForSinglePage = YES;
 		_pageControl.translatesAutoresizingMaskIntoConstraints = NO;
-		_pageControl.userInteractionEnabled = NO;
+        [_pageControl addTarget:self action:@selector(pageChanged:) forControlEvents:UIControlEventValueChanged];
 		[_bottomGradientView addSubview:_pageControl];
 		
 		[_bottomGradientView addConstraint:[NSLayoutConstraint constraintWithItem:_pageControl
@@ -177,6 +177,11 @@
 		self.bottomGradientViewLayoutConstraintHeight.constant = kBuyBottomGradientHeightWithPageControl;
 		self.bottomGradientView.bottomColor = [UIColor colorWithWhite:0 alpha:0.15f];
 	}
+}
+
+- (void)pageChanged:(id)sender {
+    UIPageControl *pageControl = (UIPageControl*)sender;
+    [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForRow:pageControl.currentPage inSection:0] atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally animated:YES];
 }
 
 - (void)setCurrentPage:(NSInteger)currentPage

--- a/Products/Product View/Variant Selection/OptionSelectionViewController.m
+++ b/Products/Product View/Variant Selection/OptionSelectionViewController.m
@@ -78,6 +78,20 @@
 	[self.tableView reloadData];
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    // Announce what this picker is for to VoiceOver users
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, self.title);
+
+    // Set VoiceOver focus to the currently selected cell or first item if none is selected
+    NSUInteger currentRow = [self.optionValues indexOfObject:self.selectedOptionValue];
+    currentRow = currentRow != NSNotFound ? currentRow : 0;
+    NSIndexPath *currentIndexPath = [NSIndexPath indexPathForRow:currentRow inSection:0];
+    OptionValueCell *currentCell = [self.tableView cellForRowAtIndexPath:currentIndexPath];
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, currentCell);
+}
+
 #pragma mark - Table View methods
 
 -(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section


### PR DESCRIPTION
Previously `UIPageControl` could not control the product image carousel which made navigating images difficult for VoiceOver users.

Product option selection has been confusing for testers. This makes it a little clearer for VoiceOver users.