### PR TITLE
Fix accessibility label of new close button

### DIFF
--- a/Products/Product View/ProductViewNavigationController.m
+++ b/Products/Product View/ProductViewNavigationController.m
@@ -35,7 +35,7 @@
 {
 	self = [super initWithRootViewController:rootViewController];
     UIBarButtonItem *leftButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemStop target:self action:@selector(dismissPopover)];
-    leftButton.accessibilityValue = NSLocalizedString(@"close", @"VoiceOver label for close button");
+    leftButton.accessibilityLabel = NSLocalizedString(@"close", @"VoiceOver label for close button");
     self.topViewController.navigationItem.leftBarButtonItem = leftButton;
 	
 	return self;


### PR DESCRIPTION
With the new system icon this is being read "stop, close, button" instead of "close, button"